### PR TITLE
Fix http build cache folder naming

### DIFF
--- a/example/hello-world/docker/http/Dockerfile
+++ b/example/hello-world/docker/http/Dockerfile
@@ -6,5 +6,5 @@ RUN go build -o hello-world-http http/main.go
 FROM alpine
 RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 RUN apk update && apk add ca-certificates
-COPY --from=build /cache/hello-world /app/
+COPY --from=build /cache/hello-world-http /app/
 ENTRYPOINT /app/hello-world-http

--- a/templates/docker/dockerfile_http.tmpl
+++ b/templates/docker/dockerfile_http.tmpl
@@ -6,5 +6,5 @@ RUN go build -o {{ .Name }}-http http/main.go
 FROM alpine
 RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 RUN apk update && apk add ca-certificates
-COPY --from=build /cache/{{ .Name }} /app/
+COPY --from=build /cache/{{ .Name }}-http /app/
 ENTRYPOINT /app/{{ .Name }}-http


### PR DESCRIPTION
One more fix to unblock #23
- Updated http cache folder to match build folder naming

